### PR TITLE
Add in-app Copyright notice

### DIFF
--- a/app/src/main/java/org/hiveway/MainActivity.java
+++ b/app/src/main/java/org/hiveway/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends BaseActivity implements ActionButtonActivity {
     private static final long DRAWER_ITEM_BLOCKED_USERS = 3;
     private static final long DRAWER_ITEM_SEARCH = 4;
     private static final long DRAWER_ITEM_PREFERENCES = 5;
+    private static final long DRAWER_ITEM_ABOUT = 6;
     private static final long DRAWER_ITEM_LOG_OUT = 7;
     private static final long DRAWER_ITEM_FOLLOW_REQUESTS = 8;
     private static final long DRAWER_ITEM_SAVED_POST = 9;
@@ -319,6 +320,7 @@ public class MainActivity extends BaseActivity implements ActionButtonActivity {
         listItem.add(new PrimaryDrawerItem().withIdentifier(DRAWER_ITEM_SAVED_POST).withName(getString(R.string.action_access_saved_post)).withSelectable(false).withIcon(GoogleMaterial.Icon.gmd_save));
         listItem.add(new DividerDrawerItem());
         listItem.add(new SecondaryDrawerItem().withIdentifier(DRAWER_ITEM_PREFERENCES).withName(getString(R.string.action_view_preferences)).withSelectable(false).withIcon(GoogleMaterial.Icon.gmd_settings));
+        listItem.add(new SecondaryDrawerItem().withIdentifier(DRAWER_ITEM_ABOUT).withName(getString(R.string.about_title_activity)).withSelectable(false).withIcon(GoogleMaterial.Icon.gmd_info));
         listItem.add(new SecondaryDrawerItem().withIdentifier(DRAWER_ITEM_LOG_OUT).withName(getString(R.string.action_logout)).withSelectable(false).withIcon(GoogleMaterial.Icon.gmd_exit_to_app));
 
         IDrawerItem[] array = new IDrawerItem[listItem.size()];
@@ -354,6 +356,9 @@ public class MainActivity extends BaseActivity implements ActionButtonActivity {
                             startActivity(intent);
                         } else if (drawerItemIdentifier == DRAWER_ITEM_PREFERENCES) {
                             Intent intent = new Intent(MainActivity.this, PreferencesActivity.class);
+                            startActivity(intent);
+                        } else if (drawerItemIdentifier == DRAWER_ITEM_ABOUT) {
+                            Intent intent = new Intent(MainActivity.this, AboutActivity.class);
                             startActivity(intent);
                         } else if (drawerItemIdentifier == DRAWER_ITEM_LOG_OUT) {
                             logout();

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -45,6 +45,18 @@
                 android:textIsSelectable="true" />
 
             <TextView
+                android:id="@+id/projectURL_TV2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:lineSpacingMultiplier="1.2"
+                android:padding="@dimen/text_content_margin"
+                android:text="@string/about_tusky_src"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textIsSelectable="true" />
+
+            <TextView
                 android:id="@+id/projectURL_TV"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,8 +223,10 @@
     <string name="about_title_activity">About</string>
     <string name="about_tusky_version">Hiveway %s</string>
     <string name="about_tusky_license">Hiveway is free and open-source software.
-        It is licensed under the GNU General Public License Version 3.
+        It is forked from Tusky, which is licensed under the GNU General Public License Version 3.
         You can view the license here: https://www.gnu.org/licenses/gpl-3.0.en.html</string>
+    <string name="about_tusky_src">Tusky source available at:\n
+        https://github.com/tuskyapp/Tusky</string>
     <!-- note to translators: the url can be changed to link to the localized version of the license -->
     <string name="about_project_site">
         Project website:\n
@@ -277,5 +279,6 @@
     <string name="hint_describe_for_visually_impaired">Describe for visually impaired</string>
     <string name="action_set_caption">Set caption</string>
     <string name="action_remove_media">Remove</string>
+
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,5 +280,4 @@
     <string name="action_set_caption">Set caption</string>
     <string name="action_remove_media">Remove</string>
 
-
 </resources>


### PR DESCRIPTION
From the comments on #1 after it was closed.

As per the GPL v3, it is required that a prominent Copyright notice is included somewhere in the UI that is visible to all users of the software, not just in the source code.

```
An interactive user interface displays "Appropriate Legal Notices"
to the extent that it includes a convenient and prominently visible
feature that (1) displays an appropriate copyright notice, and (2)
tells the user that there is no warranty for the work (except to the
extent that warranties are provided), that licensees may convey the
work under this License, and how to view a copy of this License.  If
the interface presents a list of user commands or options, such as a
menu, a prominent item in the list meets this criterion.
```